### PR TITLE
Remove unused alert classes

### DIFF
--- a/app/views/effective/style_guide/_alerts.html.haml
+++ b/app/views/effective/style_guide/_alerts.html.haml
@@ -1,4 +1,4 @@
-- variations = ['Success', 'Info', 'Notice', 'Alert', 'Warning', 'Danger']
+- variations = ['Success', 'Info', 'Warning', 'Danger']
 
 - variations.each do |variation|
   .alert{:class => "alert-#{variation.downcase}"}


### PR DESCRIPTION
Bootstrap no longer uses .alert-notice or .alert-alert
